### PR TITLE
fix serialize-javascript vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "redux-form": "^8.2.6",
     "redux-logger": "^3.0.6",
     "redux-promise": "^0.6.0",
+    "serialize-javascript": "^2.1.1",
     "wavesurfer.js": "^2.2.1",
     "webpack": "^4.41.2",
     "yarn": "^1.17.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6547,6 +6547,11 @@ serialize-javascript@^2.1.0:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.0.tgz#9310276819efd0eb128258bb341957f6eb2fc570"
   integrity sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==
 
+serialize-javascript@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.1.tgz#952907a04a3e3a75af7f73d92d15e233862048b2"
+  integrity sha512-MPLPRpD4FNqWq9tTIjYG5LesFouDhdyH0EPY3gVK4DRD5+g4aDqdNSzLIwceulo3Yj+PL1bPh6laE5+H6LTcrQ==
+
 serve-index@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"


### PR DESCRIPTION
Fixing the serialize-javascript vulnerability which will happen soon (all our apps have been affected so far).
The fix can't be done by Dependabot so I am pre-empting the inevitable. 